### PR TITLE
feat: add API key support for ACS client

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+ACS_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+ACS_API_KEY=your_api_key_here

--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ As an alternative, for Kubernetes clusters, there is the option to deploy it via
 helmfile -f genieacs-deploy-helmfile/helmfile.yaml -i apply
 ```
 
+## Running task scripts
+
+Some utility scripts live under `tasks/` and communicate with the backend.
+These scripts read configuration from a `.env` file. Copy the example file
+and set your API key before running any script:
+
+```bash
+cp .env.example .env
+# edite .env e defina ACS_API_KEY
+python tasks/<script>.py
+```
+
 ## Maintainers
 
 [@GeiserX](https://github.com/GeiserX).

--- a/tasks/acs_client.py
+++ b/tasks/acs_client.py
@@ -7,9 +7,16 @@ from typing import List, Optional
 import os
 import requests
 
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except Exception:
+    pass
+
 # ---------------------------------------------------------------------
 # Config
 BACKEND_URL: str = os.getenv("ACS_BACKEND_URL", "http://localhost:8000")
+API_KEY: str = os.getenv("ACS_API_KEY", "")
 
 
 # ---------------------------------------------------------------------
@@ -19,7 +26,8 @@ def _post(endpoint: str, payload: dict, params: Optional[dict] = None) -> dict:
     Envia POST ao backend e devolve JSON (levanta exceção para HTTP≠2xx).
     """
     url = f"{BACKEND_URL}{endpoint}"
-    resp = requests.post(url, json=payload, params=params)
+    headers = {"X-API-Key": API_KEY} if API_KEY else None
+    resp = requests.post(url, json=payload, params=params, headers=headers)
     resp.raise_for_status()
     return resp.json()
 


### PR DESCRIPTION
## Summary
- add ACS_API_KEY env var usage in ACS client
- send X-API-Key header in requests
- document ACS_API_KEY usage in README
- load API key from `.env` file

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893bfd1c300832d8fd89b96003c9437