### PR TITLE
Use async httpx client for FastAPI backend

### DIFF
--- a/backend/Dockerfile.backend
+++ b/backend/Dockerfile.backend
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY genieacs_backend_mvp.py .
-RUN pip install fastapi "uvicorn[standard]" requests
+RUN pip install fastapi "uvicorn[standard]" httpx
 ENV GENIEACS_NBI_URL=http://genieacs:7557
 CMD ["uvicorn", "genieacs_backend_mvp:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- switch request handling to `httpx.AsyncClient` with async endpoints
- install `httpx` in backend image

## Testing
- `python -m pytest`
- `pip install httpx` *(fails: Could not connect to proxy / No matching distribution found)*

------
https://chatgpt.com/codex/tasks/task_e_6893cd113a74832d896cf58f234a429a